### PR TITLE
Fix the movement of the prompt indicator when filtering

### DIFF
--- a/killer/killer.go
+++ b/killer/killer.go
@@ -127,7 +127,8 @@ func (k *Killer) OnChange(line []rune, pos int, _ rune) (newLine []rune, newPos 
 
 	bold := color.New(color.Bold).SprintFunc()
 	prompt := "  Filter processes"
-	postPrompt := fmt.Sprintf(" (%d/%d)", len(k.filtered), len(k.processes))
+	fmtlen := len(fmt.Sprintf("%d", len(k.processes)))
+	postPrompt := fmt.Sprintf(fmt.Sprintf(" (%%%dd/%%%dd)", fmtlen, fmtlen), len(k.filtered), len(k.processes))
 	if len(k.filtered) > 0 {
 		k.rt.SetPrompt(bold(prompt) + color.GreenString(postPrompt) + bold(": "))
 	} else {


### PR DESCRIPTION
Feature request:

Prompt moves as the number of items changes when characters are entered. 

before

![2017-04-05 14 35 03](https://cloud.githubusercontent.com/assets/4442708/24691493/ae25337e-1a0e-11e7-9d2f-01c894be4460.png)

after

![2017-04-05 14 35 20](https://cloud.githubusercontent.com/assets/4442708/24691495/b32e0e2c-1a0e-11e7-8f1c-e132048901e0.png)

Please feel free to close this P-R if you don't like this changes.

BTW, thanks for your amazing application.